### PR TITLE
Updated README.md with an easy link to CocoaPods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ The card.io iOS SDK includes header files and a single static library. We'll wal
 
 ### Podfile
 ```ruby
-platform :ios
-pod 'CardIO', '~> 3.10.1'
+platform :ios, '6.0'
+pod 'CardIO'
 ```
 
 ### Setup


### PR DESCRIPTION
I've noticed that you have a podspec file in the project directory. Why not tell the users that they can download the SDK via CocoaPods.
