### PR TITLE
[MINOR] Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,9 @@ The card.io iOS SDK includes header files and a single static library. We'll wal
 
 ### Setup
 
-##### If you use [CocoaPods](http://cocoapods.org), then add these lines to your podfile:
+##### If you use [CocoaPods](http://cocoapods.org), then add this line to your podfile:
 
 ```ruby
-platform :ios, '6.1'
 pod 'CardIO'
 ```
 


### PR DESCRIPTION
No need to necessarily specify platform, which could result in an error like:

[!] The platform of the target `CardIODemo` (iOS 6.1) is not compatible with `Braintree (3.7.2)` which has a minimum requirement of iOS 7.0.