### PR TITLE
Use `vendored_libraries`

### DIFF
--- a/CardIO.podspec
+++ b/CardIO.podspec
@@ -11,8 +11,7 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = '6.1'
   spec.requires_arc     = true
   spec.source_files     = 'CardIO/*.h'
-  spec.preserve_path    = 'CardIO/*.a'
   spec.frameworks       = 'AVFoundation', 'AudioToolbox', 'CoreMedia', 'CoreVideo', 'MobileCoreServices', 'OpenGLES', 'QuartzCore', 'Security', 'UIKit'
-  spec.libraries        = 'CardIO', 'c++'
-  spec.xcconfig         = { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/CardIO/CardIO"' }
+  spec.libraries        = 'c++'
+  spec.vendored_libraries = 'CardIO/libCardIO.a'
 end


### PR DESCRIPTION
This is the right way to ship a prebuilt library as a Pod. Once CocoaPods/CocoaPods#3859 is merged, this will mean that CardIO also works fine when users are integrating with `use_frameworks!`

cc @keith