### PR TITLE
Add .m so that CocoaPods will generate CardIO modulemap

### DIFF
--- a/CardIO.podspec
+++ b/CardIO.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
   spec.platform         = :ios, '6.1'
   spec.ios.deployment_target = '6.1'
   spec.requires_arc     = true
-  spec.source_files     = 'CardIO/*.h'
+  spec.source_files     = 'CardIO/*.{h,m}'
   spec.frameworks       = 'Accelerate', 'AVFoundation', 'AudioToolbox', 'CoreMedia', 'CoreVideo', 'MobileCoreServices', 'OpenGLES', 'QuartzCore', 'Security', 'UIKit'
   spec.libraries        = 'c++'
   spec.vendored_libraries = 'CardIO/libCardIO.a', 'CardIO/libopencv_core.a', 'CardIO/libopencv_imgproc.a'

--- a/CardIO/CardIO.m
+++ b/CardIO/CardIO.m
@@ -1,0 +1,7 @@
+//
+// This file exists so that CocoaPods will generate a modulemap for CardIO
+//
+// See https://github.com/card-io/card.io-iOS-SDK/issues/115
+// and https://github.com/card-io/card.io-iOS-SDK/pull/126
+// for more details
+//


### PR DESCRIPTION
This fixes the issues discussed in https://github.com/card-io/card.io-iOS-SDK/issues/115 and https://github.com/card-io/card.io-iOS-SDK/pull/126 since changing the project structure was nixed as a solution. This allows users to import CardIO from Swift _without_ using a bridging header.
