### PR TITLE
Update podspec to work with Swift imports

### DIFF
--- a/CardIO.podspec
+++ b/CardIO.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |spec|
   spec.source_files     = 'CardIO/*.{h,m}'
   spec.frameworks       = 'Accelerate', 'AVFoundation', 'AudioToolbox', 'CoreGraphics', 'CoreMedia', 'CoreVideo', 'MobileCoreServices', 'OpenGLES', 'QuartzCore', 'Security', 'UIKit'
   spec.libraries        = 'c++'
-  spec.vendored_libraries = 'CardIO/libCardIO.a', 'CardIO/libopencv_core.a', 'CardIO/libopencv_imgproc.a'
+  spec.vendored_libraries = 'CardIO/libCardIOCore.a', 'CardIO/libopencv_core.a', 'CardIO/libopencv_imgproc.a'
   spec.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
 end

--- a/CardIO.podspec
+++ b/CardIO.podspec
@@ -10,8 +10,9 @@ Pod::Spec.new do |spec|
   spec.platform         = :ios, '6.1'
   spec.ios.deployment_target = '6.1'
   spec.requires_arc     = true
-  spec.source_files     = 'CardIO/*.h'
-  spec.frameworks       = 'Accelerate', 'AVFoundation', 'AudioToolbox', 'CoreMedia', 'CoreVideo', 'MobileCoreServices', 'OpenGLES', 'QuartzCore', 'Security', 'UIKit'
+  spec.source_files     = 'CardIO/*.{h,m}'
+  spec.frameworks       = 'Accelerate', 'AVFoundation', 'AudioToolbox', 'CoreGraphics', 'CoreMedia', 'CoreVideo', 'MobileCoreServices', 'OpenGLES', 'QuartzCore', 'Security', 'UIKit'
   spec.libraries        = 'c++'
   spec.vendored_libraries = 'CardIO/libCardIO.a', 'CardIO/libopencv_core.a', 'CardIO/libopencv_imgproc.a'
+  spec.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
 end


### PR DESCRIPTION
This is a new version of https://github.com/card-io/card.io-iOS-SDK/pull/210 which works with both Objective-C and Swift. This allows Swift users to directly import CardIO without using a bridging header. This fixes the [previous issue](https://github.com/card-io/card.io-iOS-SDK/commit/12b83d6d6a37250a2fb7b373d7b65a6a5389255d#commitcomment-25310276) with the previous approach by using `-ObjC`